### PR TITLE
Allowing whitelisted multi-parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ To whitelist query parameters, use the `params` arg for the decorator:
         def get(self):
             self.write("Hello, world")
 
+Whitelisting a param will also whitelist the array version of that param:
+
+    # whitelists "some_param=", "some_param[]=", "some_param[1]="
+    @torender.prerenderable(params=["some_param"])
+
+
 ## Settings ##
 
 Using tornado application settings, you can set these parameters:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "0.1.0"
+version = "0.2.0"
 
 setup(
     name = "torender",

--- a/torender/decorators.py
+++ b/torender/decorators.py
@@ -1,6 +1,7 @@
 import tornado.web
 from tornado import httpclient, log, web, gen
 import functools
+import re
 
 try:
     from urllib.parse import urlencode
@@ -12,6 +13,9 @@ DEFAULT_REQUEST_TIMEOUT = 20.0
 
 # Service that provides prerendering functionality
 DEFAULT_PRERENDER_HOST = "http://service.prerender.io"
+
+# Regex used to strip multi-param encoding
+MULTI_PARAM_REGEX = re.compile("\[[0-9]*\]$")
 
 def prerenderable(method=None, params=None):
     """
@@ -80,14 +84,15 @@ def prerenderable(method=None, params=None):
             flattened_query_args = []
 
             for k, v in query_args.items():
-                if whitelisted_params == None or k in whitelisted_params:
+                escaped_param = MULTI_PARAM_REGEX.sub("", k)
+                if whitelisted_params == None or escaped_param in whitelisted_params:
                     for i in v:
                         flattened_query_args.append((k, i))
 
             flattened_query_args.sort()
 
             new_url = "%s?%s" % (new_url, urlencode(flattened_query_args))
-        
+
         response = None
 
         fetch_kwargs = {

--- a/torender/tests/test_decorators.py
+++ b/torender/tests/test_decorators.py
@@ -23,7 +23,7 @@ PRERENDERED_CONTENTS = """
 <h2>Hello from prerender</h2></body></html>
 """.strip().encode("utf8")
 
-ALLOWED_PARAMS = set(["a", "b", "_escaped_fragment_"])
+ALLOWED_PARAMS = set(["a", "b", "a[]", "b[]", "_escaped_fragment_"])
 
 class BaseHandler(tornado.web.RequestHandler):
     def _get(self):
@@ -90,6 +90,12 @@ class PrerenderableTestCase(_BaseTestCase):
         response = self.request("/with-params?_escaped_fragment_=&a=1&b=2&c=3")
         self.assertEqual(response.code, 200)
         self.assertEqual(response.body, PRERENDERED_CONTENTS)
+
+    def test_whitelisted_array_params(self):
+        response = self.request("/with-params?_escaped_fragment_=&a[]=1&a[]=2&b=2&c=3")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body, PRERENDERED_CONTENTS)
+
 
 class UnconfiguredPrerenderableTestCase(_BaseTestCase):
     def test_unconfigured(self):


### PR DESCRIPTION
~Adding an option (defaults to True) to~ include multi parameters in the whitelist. e.g.

```
# whitelists "some_param=", "some_param[]=", "some_param[1]="
@torender.prerenderable(params=["some_param"])
```

