### PR TITLE
Pass through redirects rather than following them to a non-prerendered location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # http://travis-ci.org/#!/dailymuse/torender
 
 language: python
+python:
+    - "pypy"
 env:
     - TRAVIS_NODE_VERSION="4" TOXENV=py27-tornado322
     - TRAVIS_NODE_VERSION="4" TOXENV=py27-tornado401


### PR DESCRIPTION
Currently, when a handler decorated with `prerenderable` redirects, `torender` follows the redirect chain and returns the response from the final destination because `prerender` itself passes through 3XX status codes instead of pre-rendering the content.

I believe the desired behaivor is that if `prerender` passes the 3XX code back to `torender`, we should then pass it back to the crawler. 

This is my first look at this code base, it's really interesting and I feel like I have a good grasp on what is going on, but I'm struggling to manually test this locally. Any tips? Also, tests failing now, looking into it, looks like a timeout thing or interpreter not found? Hmmm.