### PR TITLE
Check code directly since response may be None

### DIFF
--- a/torender/decorators.py
+++ b/torender/decorators.py
@@ -110,7 +110,7 @@ def prerenderable(method=None, params=None):
             response = yield httpclient.AsyncHTTPClient().fetch(new_url, **fetch_kwargs)
         except httpclient.HTTPError as err:
             # If we encounter a redirect, pass it through
-            if 300 <= err.response.code <= 399:
+            if 300 <= err.code <= 399:
                 self.redirect(err.response.headers['Location'], status=err.response.code)
                 return
             log.app_log.warning("HTTP error when making a request to prerender", exc_info=True)


### PR DESCRIPTION
Found out I created a bug with the last bugfix (oh no). If the prerender service times out and sends a 599, response will be None.

I'm trying to write a test case for this, but the mocking is tricky. Opening this in case we want to get this in ASAP.

The other question raised by this is why is our prerender server timing out quite a lot?